### PR TITLE
A bunch of stuff, again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ lib/**
 *.ini
 .history
 
-build
+temp

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ lib/**
 *.ttf
 *.ini
 .history
+
+build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "cimgui"]
-	path = cimgui
-	url = https://www.github.com/cimgui/cimgui.git

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(Windows) Launch",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}\\temp\\bindbc-generator\\bin\\bindbc-generate.exe",
+            "args": [
+                "--file", "${workspaceFolder}/temp/cimgui/cimgui.h", 
+                "--dpp-path", "${workspaceFolder}/temp/dpp/bin/d++.exe", 
+                "--load-all",
+                "--presets", "cimgui",
+                "--plugin-args", "cimgui-overloads=\"[${workspaceFolder}/temp/cimgui ${workspaceFolder}/temp/bindbc/cimgui d-conv]\"",
+                "--presets", "cimgui",
+                "--temp-path", "${workspaceFolder}/temp"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/temp/bindbc-generator",
+            "environment": [],
+            "console": "externalTerminal",
+            "sourceFileMap": {
+                "/c/": "C:/",
+                "c:\\": "C:\\"
+            }
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,26 @@
                 "/c/": "C:/",
                 "c:\\": "C:\\"
             }
+        },
+        {
+            "name": "(Windows) Launch Build Script",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "rdmd",
+            "args": [
+                "${workspaceFolder}/dostuff.d", 
+                "--compileImgui", 
+                "--compileDpp", 
+                "--generateBindings"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "console": "externalTerminal",
+            "sourceFileMap": {
+                "/c/": "C:/",
+                "c:\\": "C:\\"
+            }
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ I only provide OpenGL3 and SDL2 backends (see the example folder).
 These are *not included* if you install this via dub. 
 You will have to copy them from the example folder.
 
+> VERY BIG SPOILER ALERT!
+> The generator for this is NOT fully automatic and will not work for newer version of imgui.
+> REGENERATE THE BINDINGS AT YOUR OWN RISK, you will likely have to do a lot of work to make it work.
+
 I made this binding with [bindbc-generator](https://github.com/MrcSnm/bindbc-generator) with some additional things that cimgui needs, found at `source/bindbc/cimgui/additional.d`.
 The only other dub package which provides ImGui bindings is [DerelicImGui](https://github.com/extrawurst/DerelictImgui), but it is pretty old, so I made this repo that I'll be supporting for my game engine [HipremeEngine](https://github.com/MrcSnm/HipremeEngine).
 
@@ -38,6 +42,8 @@ cmake --build build --config RelWithDebInfo
 ```
 
 [-H](https://cgold.readthedocs.io/en/latest/glossary/-H.html), [-B](https://cgold.readthedocs.io/en/latest/glossary/-B.html#b)
+
+Even better, @AntonC9018 made a helper script that helps with cloning the right hash of cimgui, building it, as well as downloading and building dpp, and running the bidings generator.
 
 If you need the ImGui backend implementations to be part of the library, include the source files in `cimgui/CMakeLists.txt`.
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,80 @@
 # BindBC-Cimgui
 
-BetterC bindings from [cimgui](https://github.com/cimgui/cimgui/)
-
-This project has the implementations using BindBC-OpenGL and BindBC-SDL at the examples folder.
+BetterC bindings for [cimgui](https://github.com/cimgui/cimgui/)
 
 I tried my best to follow what @mdparker has been doing.
 
+I only provide OpenGL3 and SDL2 backends (see the example folder).
+These are *not included* if you install this via dub. 
+You will have to copy them from the example folder.
+
 I made this binding with [bindbc-generator](https://github.com/MrcSnm/bindbc-generator) with some additional things that cimgui needs, found at `source/bindbc/cimgui/additional.d`.
-The last easier dub packaged available version to use is [DerelicImGui](https://github.com/ExtraWurst/DerelicImGui) which is pretty old, so I made this repo that I'll be supporting for my game engine [HipremeEngine](https://github.com/MrcSnm/HipremeEngine);
+The only other dub package which provides ImGui bindings is [DerelicImGui](https://github.com/extrawurst/DerelictImgui), but it is pretty old, so I made this repo that I'll be supporting for my game engine [HipremeEngine](https://github.com/MrcSnm/HipremeEngine).
 
-The docking and master branch are supported right now, there is a switch available on `additional.d` called `CIMGUI_VIEWPORT_BRANCH`.
+The docking and master branch are both supported. 
+Docking can be enabled via `CIMGUI_VIEWPORT_BRANCH` version definition.
 
-If you want to use the ImGui repo implementations, you can pass a callback argument to `loadcimgui` which receives a `SharedLib` which you can then take to link the symbols, they are on the example, just modify the switch on them which will be `CIMGUI_USER_DEFINED_IMPLEMENTATION`.
+If you want to use the C++ implementations provided by ImGui, instead of defining custom ones like I did in the example project, you will need to link against them.
+In order to do this, pass a callback argument to `loadcimgui` which receives a `SharedLib` which you can then take the needed symbols from, binding them to the respective function pointers.
 
-Version from ImGui supported right now:
-## v1.79
+> Note: When you build cimgui, the implementations are not included by default. 
+> You will have to modify the make file in there to add what you need. 
+> Also the linking code and the relevant structs and constants will have to be written in D manually, by mirroring them from the C++ source.
+
+The particular implementations in the example folder allow either custom implementation or dynamically linking against a precompiled one, controlled via the constant `CIMGUI_USER_DEFINED_IMPLEMENTATION_SDL`. It is set to true by default. Change the source file to override this.
+
+I only provide so many backends, so if you're using something else, you'll have to write it on your own. Use [the official ImGui implementations](cimgui/imgui/backends) as reference.
+
+## How to build ImGui?
+
+See more info on cimgui [in their repo](cimgui).
+
+The steps are basically as follows:
+```
+git clone --recursive https://github.com/MrcSnm/bindbc-cimgui 
+cd bindbc-cimgui 
+cmake -Hcimgui -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build --config RelWithDebInfo
+```
+
+[-H](https://cgold.readthedocs.io/en/latest/glossary/-H.html), [-B](https://cgold.readthedocs.io/en/latest/glossary/-B.html#b)
+
+If you need the ImGui backend implementations to be part of the library, include the source files in `cimgui/CMakeLists.txt`.
+
+For example, here I have added the GLFW implementation and the OpenGL3 implementation:
+```
+file(GLOB IMGUI_SOURCES
+    
+    imgui/backends/imgui_impl_glfw.cpp
+    imgui/backends/imgui_impl_opengl3.cpp
+
+    cimgui.cpp
+    imgui/imgui.cpp
+    imgui/imgui_draw.cpp
+    imgui/imgui_demo.cpp
+    imgui/imgui_widgets.cpp
+	${TABLES_SOURCE}
+)
+```
+
+Note that in this case you will also likely need to mess with headers and will likely have to do static linking.
+In this case adding the following line for the include won't be enough, since you usually link against GLFW on the D side of things, so it does not compile:
+```
+target_include_directories(cimgui PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/imgui/examples/libs/glfw/include)
+```
+
+So in that case you will either have to link against the same static GLFW library at compile time in both the C++ and the D land, or link dynamically from both C++ and D land.
+
+> If you have succeeded in doing this, feel welcome to describe what you did with a PR.
+
+> I recommend writing the implementations yourself. 
+> The C++ files are almost 1-to-1 translatable to D.
+> If you do so, feel free to add it via a PR.
+
+
+## List of the currently supported versions of ImGui:
+
+### v1.79
 
 Screenshots:
 

--- a/dostuff.d
+++ b/dostuff.d
@@ -199,8 +199,8 @@ string gitCloneImgui()
     auto result = _exec(["git", "checkout", commitHash], clonedRepoPath);
     if (result.status != 0) return null;
     
-    result = _exec(["git", "submodule", "init"], clonedRepoPath);
-    if (result.status != 0) return null;
+    // result = _exec(["git", "submodule", "init"], clonedRepoPath);
+    // if (result.status != 0) return null;
 
     result = _exec(["git", "submodule", "update", "--init", "--recursive"], clonedRepoPath);
     if (result.status != 0) return null;
@@ -284,6 +284,7 @@ void generateBindingsWorkflow()
         "--file", cimguiHeaderPath, 
         "--temp-path", op.tempDirectory, 
         "--plugin-args", 
+        // FIXME please. Change the format on this, or take the arguments more smartly, this is an actual disaster.
         `cimgui-overloads="[%s %s %s]"`.format(imguiPath, cimguiPluginGenPath, "d-conv"),
         "--presets", "cimgui"
     ];
@@ -314,7 +315,7 @@ auto _exec(string[] args, string workingDirectory = null)
 {
     string cmd = escapeShellCommand(args);
     log(cmd);
-    return executeShell(cmd, null, Config.none, size_t.max, workingDirectory, nativeShell);
+    return execute(args, null, Config.none, size_t.max, workingDirectory);
 }
 
 bool existsCommand(string command)

--- a/dostuff.d
+++ b/dostuff.d
@@ -1,0 +1,285 @@
+module dostuff;
+
+import std.string;
+import std.file;
+import std.path;
+import std.range;
+import std.algorithm;
+import std.process;
+import std.getopt;
+import std.experimental.logger;
+
+struct Options
+{
+    @("Path to temporary directory, `temp` by default.") 
+    string tempDirectory;
+
+    @("Path to d++ executable. Only needed when doing bindings. Found in path if not provided.") 
+    string dppExecutablePath;
+
+    @("Path to bindbc generator. Only needed when doing bindings.") 
+    string generatorRepoPath;
+
+    @("Path to `cimgui.h`.")
+    string cimguiHeaderPath;
+
+    @("Whether to get cimgui from github and compile into a dll and lib.")
+    bool compileImgui;
+
+    @("Whether to regenerate bindbc-cimgui bindings using the generator.")
+    bool generateBindings;
+    
+    @("Whether to get dpp from github and compile it.")
+    bool compileDpp;
+}
+
+__gshared Options op;
+__gshared bool hasErrors;
+
+void _error(string message)
+{
+    hasErrors = true;
+    error(message);
+}
+
+auto _exec(string[] args, string workingDirectory = null)
+{
+    string cmd = escapeShellCommand(args);
+    log(cmd);
+    return executeShell(cmd, null, Config.none, size_t.max, workingDirectory, nativeShell);
+}
+
+bool existsCommand(string command)
+{
+    version (Windows)
+    {
+        return executeShell(escapeShellCommand(["where", command])).status == 0;
+    }
+    assert(0, "Linux and the alike are not implemented");
+}
+
+bool checkCommandsExist(string[] commands)
+{
+    foreach (command; commands)
+    {
+        if (!existsCommand(command))
+        {
+            _error("`" ~ command ~ "` not found in path");
+        }   
+    }
+    return !hasErrors;
+}
+
+int main(string[] args)
+{
+    string getoptMixin()
+    {
+        auto ret = "auto helpInformation = getopt(args";
+        static foreach (field; Options.tupleof)
+        {
+            import std.format;
+            ret ~= `, "%s", "%s", &op.%1$s`.format(__traits(identifier, field), __traits(getAttributes, field)[0]);
+        }
+        ret ~= ");";
+        return ret;
+    }
+    // pragma(msg, getoptMixin());
+    mixin(getoptMixin());
+    if (helpInformation.helpWanted)
+    {
+        defaultGetoptPrinter("Help message", helpInformation.options);
+        return 0;
+    }
+
+    void ensurePathExistsIfProvided(string name, string path)
+    {
+        if (path && !exists(path))
+        {
+            _error(name ~ " not found by the specified path " ~ path);
+        }
+    }
+    ensurePathExistsIfProvided("Dpp", op.dppExecutablePath);
+    ensurePathExistsIfProvided("Generator", op.generatorRepoPath);
+    ensurePathExistsIfProvided("cimgui header", op.cimguiHeaderPath);
+
+    if (op.compileDpp && op.dppExecutablePath)
+    {
+        _error("Incompatible arguments: `compileDpp` and `dppExecutablePath`");
+    }
+
+    if (op.compileImgui && op.cimguiHeaderPath)
+    {
+        _error("Incompatible arguments: `compileImgui` and `cimguiHeaderPath`");
+    }
+
+    op.tempDirectory = absolutePath(op.tempDirectory ? op.tempDirectory : "temp");
+    mkdirRecurse(op.tempDirectory);
+
+    if (hasErrors)
+        return 1;
+
+    if (op.compileDpp)
+    {
+        op.dppExecutablePath = dppCompilationWorkflow();
+
+        if (!op.dppExecutablePath)
+            return 1;
+
+        log("Dpp written to " ~ op.dppExecutablePath);
+    }
+
+    if (op.compileImgui)
+    {
+        string outputDirectory = imguiCompilationWorkflow();
+
+        if (!outputDirectory)
+            return 1;
+        
+        log("Imgui binaries written to " ~ outputDirectory);
+    }
+
+    if (op.generateBindings)
+    {
+        generateBindingsWorkflow();
+    }
+
+    return hasErrors ? 1 : 0;
+}
+
+string takeAfterLast(string str, string pattern)
+{
+    auto index = lastIndexOf(str, pattern);
+    return str[index + 1..$];
+}
+
+// Returns the path to the cloned repo
+string gitClone(string repoUrl, string branch = null)
+{
+    // `a/b/name` gives us `name`
+    string repoName = repoUrl.takeAfterLast("/");
+    string repoPath = buildPath(op.tempDirectory, repoName);
+    if (exists(repoPath))
+    {
+        log("Found " ~ repoName ~ " clone at " ~ repoPath ~ ", skipping cloning.");
+        return repoPath;
+    }
+
+    string[] args = ["git", "clone", "--recursive", repoUrl];
+    if (branch)
+    {
+        args ~= "--branch=" ~ branch;
+    }
+
+    auto result = _exec(args, op.tempDirectory);
+    if (result.status == 0)
+        return repoPath;
+
+    _error("Failed to clone " ~ repoName ~ ": " ~ result.output);
+    return null;
+}
+
+string dppCompilationWorkflow()
+{
+    const dppRepoUrl = "https://github.com/atilaneves/dpp";
+    log("You will need to install LLVM if it's not installed already, see the dpp repo: " ~ dppRepoUrl);
+    
+    if (!checkCommandsExist(["git", "dub"]))
+        return null;
+
+    const dppClonedRepoPath = gitClone(dppRepoUrl);
+    if (!dppClonedRepoPath)
+        return null;
+
+    const result = _exec(["dub", "build"], dppClonedRepoPath);
+    if (result.status != 0)
+    {
+        _error("Failed to build dpp: " ~ result.output);
+        return null;
+    }
+
+    string dppExecutablePath;
+    version (Windows)
+    {
+        dppExecutablePath = buildPath(dppClonedRepoPath, "bin/d++.exe");
+        if (!exists(dppExecutablePath))
+        {
+            _error("Expected d++ at " ~ dppExecutablePath);
+        }
+    }
+    return dppExecutablePath;
+}
+
+string imguiCompilationWorkflow()
+{
+    const imguiRepoUrl = "https://www.github.com/cimgui/cimgui";
+    const imguiCommitHash = "";
+    const imguiBranch = "docking_inter";
+
+    if (!checkCommandsExist(["git", "cmake"]))
+        return null;
+    
+    // TODO: Clone a specific hash per version?
+    const imguiClonedRepoPath = gitClone(imguiRepoUrl, imguiBranch);
+    if (!imguiClonedRepoPath)
+        return null;
+
+    // cmake -Hcimgui -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    const imguiBuildDirectory = "imgui_build";
+    const configuration = "RelWithDebInfo";
+    auto result = _exec(
+        ["cmake", "-Hcimgui", "-B" ~ imguiBuildDirectory, "-DCMAKE_BUILD_TYPE=" ~ configuration], op.tempDirectory);
+    if (result.status != 0)
+    {
+        _error("Failed to run cmake: " ~ result.output);
+        return null;
+    }
+
+    // cmake --build build --config RelWithDebInfo
+    result = _exec(["cmake", "--build", imguiBuildDirectory, "--config", configuration], op.tempDirectory);
+    if (result.status != 0)
+    {
+        _error("Failed to run cmake build: " ~ result.output);
+        return null;
+    }
+
+    // The output should be in RelWithDebInfo
+    const outputDirectory = buildPath(op.tempDirectory, "build", configuration);
+    log("The output of imgui compilation should be in " ~ outputDirectory);
+    
+    return outputDirectory;
+}
+
+
+void generateBindingsWorkflow()
+{
+    assert(0, "TODO: Not yet implemented");
+    // The steps:
+    // 1. Clone the generator if not yet provided.
+    // 2. Clone cimgui if it is not found in the temp directory.
+    // 3. Invoke the generator with the command from `generate/generate.bat`.
+    //
+    // I have already parametrized the plugins folder path, the temp folder path and the dpp path.
+    // We should make it not depend on its position in the source tree.
+    // We should allow to pass output folder as argument.
+
+
+    // string generatorExecutable;
+    // string generatorFolder;
+    // if (op.generatorRepoPath)
+    // {
+    //     generatorFolder = op.generatorRepoPath;
+    // }
+    // else
+    // {
+    //     generatorFolder   
+    // }
+
+    // version (Windows)
+    // {
+    //     generatorExecutable = buildPath(generatorFolder, "bin", "bindbc-generator.exe");
+    // }
+    // else
+    // {
+    //     assert(0, "Non-windows not supported yet");
+    // }
+}

--- a/example/dub.json
+++ b/example/dub.json
@@ -4,9 +4,8 @@
 	],
 	"copyright": "Copyright © 2020, Hipreme",
 	"dependencies": {
-		"bindbc-opengl": "~>0.13.0",
-		"bindbc-sdl": "~>0.19.1",
-		"bindbc-cimgui": "~master"
+		"bindbc-opengl": "~>1.0.0",
+		"bindbc-sdl": "~>0.19.2"
 	},
 	"description": "A minimal bindbc-cimgui example using sdl and opengl",
 	"importPaths": [
@@ -14,15 +13,22 @@
 		"../source"
 	],
 	"libs": [
-		"../lib/bindbc-cimgui"
+		"../lib/cimgui"
 	],
 	"license": "BSL-1.0",
 	"name": "bindbc-cimgui_sample",
 	"sourcePaths": [
 		"source"
 	],
+	"lflags-windows": [
+		"/LIBPATH:bin",
+		"/NODEFAULTLIB:libcmt",
+		"/NODEFAULTLIB:libvcruntime",
+		"/NODEFAULTLIB:libucrt"
+	],
 	"targetPath": "bin",
 	"versions": [
+		"CIMGUI_VIEWPORT_BRANCH",
 		"SDL_208",
 		"BindSDL_TTF",
 		"BindSDL_Image",

--- a/example/dub.json
+++ b/example/dub.json
@@ -5,7 +5,7 @@
 	"copyright": "Copyright © 2020, Hipreme",
 	"dependencies": {
 		"bindbc-opengl": "~>1.0.0",
-		"bindbc-sdl": "~>0.19.2"
+		"bindbc-sdl": "~>1.0.0"
 	},
 	"description": "A minimal bindbc-cimgui example using sdl and opengl",
 	"importPaths": [
@@ -18,15 +18,10 @@
 	"license": "BSL-1.0",
 	"name": "bindbc-cimgui_sample",
 	"sourcePaths": [
-		"source"
-	],
-	"lflags-windows": [
-		"/LIBPATH:bin",
-		"/NODEFAULTLIB:libcmt",
-		"/NODEFAULTLIB:libvcruntime",
-		"/NODEFAULTLIB:libucrt"
+		"source", "../source"
 	],
 	"targetPath": "bin",
+	"workingDirectory": "bin",
 	"versions": [
 		"CIMGUI_VIEWPORT_BRANCH",
 		"SDL_208",

--- a/example/dub.json
+++ b/example/dub.json
@@ -18,7 +18,7 @@
 	"license": "BSL-1.0",
 	"name": "bindbc-cimgui_sample",
 	"sourcePaths": [
-		"source", "../source"
+		"source"
 	],
 	"targetPath": "bin",
 	"workingDirectory": "bin",

--- a/example/dub.selections.json
+++ b/example/dub.selections.json
@@ -1,0 +1,8 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"bindbc-loader": "1.0.1",
+		"bindbc-opengl": "1.0.0",
+		"bindbc-sdl": "1.0.1"
+	}
+}

--- a/example/dub.selections.json
+++ b/example/dub.selections.json
@@ -1,9 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"bindbc-cimgui": "~master",
-		"bindbc-loader": "0.3.2",
-		"bindbc-opengl": "0.13.0",
-		"bindbc-sdl": "0.19.1"
-	}
-}

--- a/example/source/app.d
+++ b/example/source/app.d
@@ -55,8 +55,6 @@ void loadLibs()
     }
     if(!loadcimgui(additionalLoadAll))
         writeln("Could not read cimgui");
-
-
 }
 
 
@@ -72,7 +70,8 @@ int main()
     io.DisplaySize.x = 1280;
     io.DisplaySize.y = 720;
     io.DeltaTime = 1f / 60f;
-    //For the non docking
+
+    // Use docking
     version(CIMGUI_VIEWPORT_BRANCH)
     {
         io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;           // Enable Docking
@@ -94,7 +93,6 @@ int main()
 
     while(!quit)
     {
-
         SDL_Event e;
 		while(SDL_PollEvent(&e)) 
 		{

--- a/example/source/app.d
+++ b/example/source/app.d
@@ -25,8 +25,7 @@ SDL_Window* createSDL_GL_Window()
 	SDL_GL_SetAttribute(SDL_GLattr.SDL_GL_DOUBLEBUFFER, 1);
 	SDL_GL_SetAttribute(SDL_GLattr.SDL_GL_DEPTH_SIZE, 24);
 	SDL_GL_SetAttribute(SDL_GLattr.SDL_GL_STENCIL_SIZE, 8);
-	alias f = SDL_WindowFlags;
-	SDL_WindowFlags flags = (f.SDL_WINDOW_OPENGL | f.SDL_WINDOW_RESIZABLE | f.SDL_WINDOW_ALLOW_HIGHDPI);
+	SDL_WindowFlags flags = (SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
 
 	SDL_Window* window = SDL_CreateWindow("GL Window", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, flags);
 	SDL_GLContext ctx = SDL_GL_CreateContext(window);
@@ -46,11 +45,11 @@ void loadLibs()
 
     import bindbc.loader : SharedLib;
     void function (SharedLib lib) additionalLoadAll;
-    static if(!CIMGUI_USER_DEFINED_IMPLEMENTATION)
+    static if(!CIMGUI_USER_DEFINED_IMPLEMENTATION_SDL)
     {
         additionalLoadAll = (SharedLib lib)
         {
-            //bindGLImgui(lib);
+            // bindGLImgui(lib);
             //bindSDLImgui(lib);
         };
     }
@@ -74,7 +73,7 @@ int main()
     io.DisplaySize.y = 720;
     io.DeltaTime = 1f / 60f;
     //For the non docking
-    static if(CIMGUI_VIEWPORT_BRANCH)
+    version(CIMGUI_VIEWPORT_BRANCH)
     {
         io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;           // Enable Docking
         io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;         // Enable Multi-Viewport / Platform Windows
@@ -105,7 +104,7 @@ int main()
 				case SDL_QUIT:
 					quit = true;
 					break;
-                static if(CIMGUI_VIEWPORT_BRANCH)
+                version(CIMGUI_VIEWPORT_BRANCH)
                 {
                     case SDL_WINDOWEVENT:
                     if (e.window.event == SDL_WINDOWEVENT_CLOSE && e.window.windowID == SDL_GetWindowID(gWindow))
@@ -140,7 +139,7 @@ int main()
         igRender();
         ImGui_ImplOpenGL3_RenderDrawData(igGetDrawData());
 
-        static if(CIMGUI_VIEWPORT_BRANCH)
+        version(CIMGUI_VIEWPORT_BRANCH)
         {
             if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
             {

--- a/example/source/imgui_backend/impl_sdl.d
+++ b/example/source/imgui_backend/impl_sdl.d
@@ -6,17 +6,18 @@
 
 module imgui_backend.impl_sdl;
 // // SDL
-
-enum CIMGUI_USER_DEFINED_IMPLEMENTATION = true;
 import bindbc.sdl;
 
-static if(CIMGUI_USER_DEFINED_IMPLEMENTATION)
+/// Whether to use the implemetation defined in D, or link against compiled ImGUI backend. 
+enum CIMGUI_USER_DEFINED_IMPLEMENTATION_SDL = true;
+
+version(CIMGUI_USER_DEFINED_IMPLEMENTATION_SDL)
 {
     import bindbc.cimgui;
     import core.stdc.string : memset, strncpy, strncmp;
     version(Windows)
     {
-        static if(CIMGUI_VIEWPORT_BRANCH)
+        version(CIMGUI_VIEWPORT_BRANCH)
         {
             pragma(lib, "user32");
             import core.sys.windows.windows : GetWindowLong, LONG, HWND, SetWindowLong,
@@ -847,7 +848,8 @@ static if(CIMGUI_USER_DEFINED_IMPLEMENTATION)
 
     }
 }
-else //Uses DLL
+else    // CIMGUI_USER_DEFINED_IMPLEMENTATION_SDL
+        // binds functions dynamically
 {
     import bindbc.loader : SharedLib, bindSymbol;
     extern(C) @nogc nothrow

--- a/generate/generate.bat
+++ b/generate/generate.bat
@@ -1,2 +1,2 @@
 cd ../bindbc-generator
-dub -- --load-all -r -a cimgui-overloads="[../cimgui ../source/bindbc/cimgui d-conv]"
+dub -- --load-all --recompile --plugin-args cimgui-overloads="[../cimgui ../source/bindbc/cimgui d-conv]"

--- a/generate/generate.bat
+++ b/generate/generate.bat
@@ -1,2 +1,4 @@
+pushd .
 cd ../bindbc-generator
-dub -- --load-all --recompile --plugin-args cimgui-overloads="[../cimgui ../source/bindbc/cimgui d-conv]"
+dub -- --recompile --load-all --file="../cimgui/cimgui.h" --plugin-args cimgui-overloads="[../cimgui ../source/bindbc/cimgui2 d-conv]" --dpp-path="E:\Coding\D\dpp\bin\d++.exe" --presets="cimgui"
+popd

--- a/source/bindbc/cimgui/additional.d
+++ b/source/bindbc/cimgui/additional.d
@@ -33,9 +33,6 @@ void IM_DELETE(T)(ref T* p){if(p)destroy(p); igMemFree(p);}
     return cast(T*)ptr;
 }
 
-//Using viewport branch right now, don't want to bother master as it is already 900 commits behind viwport
-enum CIMGUI_VIEWPORT_BRANCH = true;
-
 //Now the more specifics one that should not be used extensively
 /**
 * ImVector_reserve dependency
@@ -93,13 +90,13 @@ void ImVector_push_back(T)(ref T vec, const ref typeof(*T.Data) v)
 
 //NOT AUTO-GENERATED, CIMGUI SPECIFIC:
 
-static if(CIMGUI_VIEWPORT_BRANCH)
+version(CIMGUI_VIEWPORT_BRANCH)
 {
     // NOTE: Some function pointers in the ImGuiPlatformIO structure are not C-compatible because of their
-// use of a complex return type. To work around this, we store a custom CimguiStorage object inside
-// ImGuiIO::BackendLanguageUserData, which contains C-compatible function pointer variants for these
-// functions. When a user function pointer is provided, we hook up the underlying ImGuiPlatformIO
-// function pointer to a thunk which accesses the user function pointer through CimguiStorage.
+    // use of a complex return type. To work around this, we store a custom CimguiStorage object inside
+    // ImGuiIO::BackendLanguageUserData, which contains C-compatible function pointer variants for these
+    // functions. When a user function pointer is provided, we hook up the underlying ImGuiPlatformIO
+    // function pointer to a thunk which accesses the user function pointer through CimguiStorage.
     import bindbc.cimgui.types;
 
     extern(C) struct CimguiStorage

--- a/source/bindbc/cimgui/cimguiload.d
+++ b/source/bindbc/cimgui/cimguiload.d
@@ -1121,6 +1121,8 @@ private bool _load()
 	lib.bindSymbol(cast(void**)&ImVector_ImWchar_UnInit, "ImVector_ImWchar_UnInit");
 	if(additionalLoad != null)
 		additionalLoad(lib);
-	static if(CIMGUI_VIEWPORT_BRANCH)
+	version(CIMGUI_VIEWPORT_BRANCH)
+	{
 		bindCimguiStorage(lib);
+	}
 }

--- a/source/bindbc/cimgui/cimguiload.d
+++ b/source/bindbc/cimgui/cimguiload.d
@@ -61,7 +61,7 @@ private bool _load()
         import std.conv:to;
         foreach(err; errors)
         {
-            writeln(to!string(err.message));
+            writeln("Error " ~ to!string(err.message) );
         }
     }
     return isOkay;


### PR DESCRIPTION
**Summary**:
- Improve the readme (fix grammar, poor wording; add build instructions, etc.);
- Remove the useless cimgui submodule.
- Provide a utility to build cimgui, dpp, the generator, and run it. Currently only works on Windows. You'll have to fill in Linux and the alike yourself.
- Update bindbc dependencies to `1.0.0`;
- Fix some enum vs version bugs in imgui impls;
- Added honest to goodness spoilers in the readme;
- Some more stuff I missed.

I wouldn't recommend to merge until you fix the generator issues, even though I did a lot of useful stuff. (I spent 3 whole days on this, I don't know why I did this.) Also, the example doesn't build, please figure out why (linker errors, I really have no idea, but probably something to do with the actual commit version of cimgui used). Again, it never worked for me, so I don't have anything to compare against. I'm really looking forward to your help.

Building imgui is no longer a hassle though, use my helper script.