### PR TITLE
Make sure it works and fix some issues

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,9 +28,9 @@
             "name": "(Windows) Launch Build Script",
             "type": "cppvsdbg",
             "request": "launch",
-            "program": "rdmd",
-            "args": [
-                "${workspaceFolder}/dostuff.d", 
+            "preLaunchTask": "build_helper_script",
+            "program": "regenerate.exe",
+            "args": [ 
                 "--compileImgui", 
                 "--compileDpp", 
                 "--generateBindings"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build_helper_script",
+            "command": "dmd",
+            "args": [
+                "regenerate.d"
+            ]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,6 +5,7 @@
             "label": "build_helper_script",
             "command": "dmd",
             "args": [
+                "-g",
                 "regenerate.d"
             ]
         }

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ You will have to copy them from the example folder.
 > VERY BIG SPOILER ALERT!
 > The generator for this is NOT fully automatic and will not work for newer version of imgui.
 > REGENERATE THE BINDINGS AT YOUR OWN RISK, you will likely have to do a lot of work to make it work.
+> There is a helper script `regenerate.d` for doing this, which you may want to use.
 
 I made this binding with [bindbc-generator](https://github.com/MrcSnm/bindbc-generator) with some additional things that cimgui needs, found at `source/bindbc/cimgui/additional.d`.
-The only other dub package which provides ImGui bindings is [DerelicImGui](https://github.com/extrawurst/DerelictImgui), but it is pretty old, so I made this repo that I'll be supporting for my game engine [HipremeEngine](https://github.com/MrcSnm/HipremeEngine).
+The only other dub package which provides ImGui bindings is [DerelictImGui](https://github.com/extrawurst/DerelictImgui), but it is pretty old, so I made this repo that I'll be supporting for my game engine [HipremeEngine](https://github.com/MrcSnm/HipremeEngine).
 
 The docking and master branch are both supported. 
 Docking can be enabled via `CIMGUI_VIEWPORT_BRANCH` version definition.
@@ -27,7 +28,7 @@ In order to do this, pass a callback argument to `loadcimgui` which receives a `
 
 The particular implementations in the example folder allow either custom implementation or dynamically linking against a precompiled one, controlled via the constant `CIMGUI_USER_DEFINED_IMPLEMENTATION_SDL`. It is set to true by default. Change the source file to override this.
 
-I only provide so many backends, so if you're using something else, you'll have to write it on your own. Use [the official ImGui implementations](cimgui/imgui/backends) as reference.
+I only provide so many backends, so if you're using something else, you'll have to write it on your own. Use [the official ImGui implementations](https://github.com/ocornut/imgui/tree/master/backends) as reference.
 
 ## How to build ImGui?
 
@@ -43,7 +44,8 @@ cmake --build build --config RelWithDebInfo
 
 [-H](https://cgold.readthedocs.io/en/latest/glossary/-H.html), [-B](https://cgold.readthedocs.io/en/latest/glossary/-B.html#b)
 
-Even better, @AntonC9018 made a helper script that helps with cloning the right hash of cimgui, building it, as well as downloading and building dpp, and running the bidings generator.
+Even better, @AntonC9018 made a helper script that helps with cloning the right hash of cimgui, building it, as well as downloading and building dpp, and running the bidings generator. 
+Run it by doing `rdmd regenerate.d`.
 
 If you need the ImGui backend implementations to be part of the library, include the source files in `cimgui/CMakeLists.txt`.
 

--- a/dub.json
+++ b/dub.json
@@ -9,7 +9,6 @@
 	],
 	"copyright": "Copyright © 2020, Hipreme",
 	"dependencies": {
-		"bindbc-generate": "~>1.0.0",
 		"bindbc-loader": "~>1.0.1"
 	},
 	"description": "Minimal C Dear ImGUI+SDL test",

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,8 +1,6 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"bindbc-generate": "1.0.0",
-		"bindbc-loader": "0.3.2",
-		"regexes": {"path":"C:/Users/Hipreme/AppData/Local/dub/packages/bindbc-generate-1.0.0/bindbc-generate/regexes"}
+		"bindbc-loader": "1.0.1"
 	}
 }

--- a/example/dub.selections.json
+++ b/example/dub.selections.json
@@ -2,10 +2,8 @@
 	"fileVersion": 1,
 	"versions": {
 		"bindbc-cimgui": {"path":"../"},
-		"bindbc-generate": "1.0.0",
 		"bindbc-loader": "1.0.1",
 		"bindbc-opengl": "1.0.0",
-		"bindbc-sdl": "1.0.1",
-		"regexes": {"path":"C:/Users/Hipreme/AppData/Local/dub/packages/bindbc-generate-1.0.0/bindbc-generate/regexes"}
+		"bindbc-sdl": "1.0.1"
 	}
 }


### PR DESCRIPTION
**Summary:**
- Added an option allowing to change the target branch of imgui (docking or master). `docking` is the default;
- Set in stone the hashes of cimgui that would end up being cloned. This is to prevent it from breaking when the script is rerun when newer versions come out;
- Some corrections in the readme, e.g. fixing broken links;
- Remove absolute paths in `dub.json`;
- Remove `bindbc-generate` dependency from `dub.json`. That one is only needed to generate bindings, but the repo provides pregenerated bindings;
- Made `launch.json` build the script, then run it. It still doesn't load debug symbols, I don't know why they are not compiled into the executable by default. I suppose there is a compiler flag for that.